### PR TITLE
feat: instrument with otel and metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,18 @@ Python 3.12, FastAPI, aiokafka, Redis, Postgres, Terraform, GitHub Actions, dbt.
 ## Consistency & Logging
 Eventual consistency: read side may lag. Structured JSON logs carry `trace_id`, `span_id`, and `order_id` for each event.
 
+## Observability
+Both the FastAPI producer and async consumer load `configs/logging.yaml` for structured logs and `configs/otel.yaml` to configure OpenTelemetry exporters. FastAPI routes and Kafka loops emit spans, and metrics are exposed via `prometheus_client` at `/metrics`.
+
+To check metrics locally:
+
+```bash
+uvicorn app.producer.main:app --port 8000 &
+curl -s http://localhost:8000/metrics | head
+```
+
+Stop the server after inspection.
+
 ## dbt Nightly
 A scheduled GitHub Action runs dbt models and publishes docs at 05:00 UTC.
 

--- a/app/consumer/worker.py
+++ b/app/consumer/worker.py
@@ -1,15 +1,42 @@
 import asyncio
 import io
 import json
+import logging.config
 import os
+from pathlib import Path
 
+import yaml
 from aiokafka import AIOKafkaConsumer
 from fastavro import schemaless_reader
+from opentelemetry import trace
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from prometheus_client import Counter, start_http_server
 
-from app.consumer.processors import enrich, fraud
 from app.consumer.dedup import deduplicate
+from app.consumer.processors import enrich, fraud
 
-with open(os.path.join(os.path.dirname(__file__), "../producer/schemas/order_event.avsc")) as f:
+CONFIG_DIR = Path(__file__).resolve().parents[2] / "configs"
+with open(CONFIG_DIR / "logging.yaml") as f:
+    logging.config.dictConfig(yaml.safe_load(f))
+
+with open(CONFIG_DIR / "otel.yaml") as f:
+    otel_config = yaml.safe_load(f)
+
+endpoint = os.path.expandvars(otel_config["exporter"]["otlp"]["endpoint"])
+trace.set_tracer_provider(TracerProvider())
+trace.get_tracer_provider().add_span_processor(
+    BatchSpanProcessor(OTLPSpanExporter(endpoint=endpoint))
+)
+tracer = trace.get_tracer(__name__)
+
+processed_events = Counter("consumer_events_total", "Total events consumed")
+start_http_server(int(os.getenv("METRICS_PORT", "8001")))
+
+with open(
+    os.path.join(os.path.dirname(__file__), "../producer/schemas/order_event.avsc")
+) as f:
     ORDER_SCHEMA = json.load(f)
 
 
@@ -22,14 +49,16 @@ async def consume() -> None:
     await consumer.start()
     try:
         async for msg in consumer:
-            data = schemaless_reader(io.BytesIO(msg.value), ORDER_SCHEMA)
-            if await deduplicate(data["event_id"]):
-                continue
-            data = await enrich.process(data)
-            flagged = await fraud.check(data)
-            if flagged:
-                # TODO: publish to flagged topic
-                pass
+            processed_events.inc()
+            with tracer.start_as_current_span("consume_message"):
+                data = schemaless_reader(io.BytesIO(msg.value), ORDER_SCHEMA)
+                if await deduplicate(data["event_id"]):
+                    continue
+                data = await enrich.process(data)
+                flagged = await fraud.check(data)
+                if flagged:
+                    # TODO: publish to flagged topic
+                    pass
     finally:
         await consumer.stop()
 

--- a/app/producer/main.py
+++ b/app/producer/main.py
@@ -1,16 +1,42 @@
 import io
 import json
+import logging.config
 import os
+from pathlib import Path
 
+import yaml
 from aiokafka import AIOKafkaProducer
-from fastapi import FastAPI
+from fastapi import FastAPI, Response
 from fastavro import schemaless_writer
+from opentelemetry import trace
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from prometheus_client import CONTENT_TYPE_LATEST, Counter, generate_latest
+
+CONFIG_DIR = Path(__file__).resolve().parents[2] / "configs"
+with open(CONFIG_DIR / "logging.yaml") as f:
+    logging.config.dictConfig(yaml.safe_load(f))
+
+with open(CONFIG_DIR / "otel.yaml") as f:
+    otel_config = yaml.safe_load(f)
+
+endpoint = os.path.expandvars(otel_config["exporter"]["otlp"]["endpoint"])
+trace.set_tracer_provider(TracerProvider())
+trace.get_tracer_provider().add_span_processor(
+    BatchSpanProcessor(OTLPSpanExporter(endpoint=endpoint))
+)
+tracer = trace.get_tracer(__name__)
 
 app = FastAPI()
+FastAPIInstrumentor.instrument_app(app)
 producer: AIOKafkaProducer | None = None
 
 with open(os.path.join(os.path.dirname(__file__), "schemas", "order_event.avsc")) as f:
     ORDER_SCHEMA = json.load(f)
+
+events_counter = Counter("producer_events_total", "Total events produced")
 
 
 @app.on_event("startup")
@@ -30,11 +56,18 @@ async def shutdown() -> None:
 
 @app.post("/events")
 async def publish_event(event: dict) -> dict:
+    events_counter.inc()
     buf = io.BytesIO()
     schemaless_writer(buf, ORDER_SCHEMA, event)
-    await producer.send_and_wait(
-        os.getenv("KAFKA_TOPIC_ORDERS", "orders.raw"),
-        buf.getvalue(),
-        key=event["order_id"].encode(),
-    )
+    with tracer.start_as_current_span("send_kafka_message"):
+        await producer.send_and_wait(
+            os.getenv("KAFKA_TOPIC_ORDERS", "orders.raw"),
+            buf.getvalue(),
+            key=event["order_id"].encode(),
+        )
     return {"status": "ok"}
+
+
+@app.get("/metrics")
+async def metrics() -> Response:
+    return Response(generate_latest(), media_type=CONTENT_TYPE_LATEST)


### PR DESCRIPTION
## Summary
- load logging and OpenTelemetry configs for producer and consumer
- trace FastAPI and Kafka loops and expose Prometheus metrics
- document metrics check in README

## Testing
- `pytest -q` *(fails: KafkaConnectionError, httpx.ConnectError)*
- `curl -s http://localhost:8001/metrics | head -n 20`
- `pre-commit run --files app/producer/main.py app/consumer/worker.py README.md` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a687865094832ea423b35a3d4f0a4b