### PR TITLE
Add health checks and network to compose services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
       ZOOKEEPER_CLIENT_PORT: 2181
     ports:
       - '2181:2181'
+    networks:
+      - pipeline-net
 
   kafka:
     image: confluentinc/cp-kafka:7.5.0
@@ -17,6 +19,14 @@ services:
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
     ports:
       - '9092:9092'
+    healthcheck:
+      test: ["CMD", "bash", "-c", "kafka-topics --bootstrap-server localhost:9092 --list"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    networks:
+      - pipeline-net
 
   schema-registry:
     image: confluentinc/cp-schema-registry:7.5.0
@@ -28,6 +38,8 @@ services:
       SCHEMA_REGISTRY_LISTENERS: http://0.0.0.0:8081
     ports:
       - '8081:8081'
+    networks:
+      - pipeline-net
 
   postgres:
     image: postgres:15
@@ -37,17 +49,33 @@ services:
       POSTGRES_DB: events
     ports:
       - '5432:5432'
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - pipeline-net
 
   redis:
     image: redis:7
     ports:
       - '6379:6379'
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - pipeline-net
 
   jaeger:
     image: jaegertracing/all-in-one:1.55
     ports:
       - '16686:16686'
       - '4317:4317'
+    networks:
+      - pipeline-net
 
   prometheus:
     image: prom/prometheus:v2.45.0
@@ -55,11 +83,15 @@ services:
       - ./configs/prometheus.yml:/etc/prometheus/prometheus.yml
     ports:
       - '9090:9090'
+    networks:
+      - pipeline-net
 
   grafana:
     image: grafana/grafana:10.2.3
     ports:
       - '3000:3000'
+    networks:
+      - pipeline-net
 
   app-producer:
     image: python:3.12-slim
@@ -75,6 +107,14 @@ services:
       - kafka
     ports:
       - '8000:8000'
+    healthcheck:
+      test: ["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:8000/health')\""]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    networks:
+      - pipeline-net
 
   app-consumer:
     image: python:3.12-slim
@@ -87,3 +127,15 @@ services:
       KAFKA_TOPIC_ORDERS: orders.raw
     depends_on:
       - kafka
+    healthcheck:
+      test: ["CMD-SHELL", "python -c \"import socket; socket.create_connection(('kafka', 9092), timeout=5)\""]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    networks:
+      - pipeline-net
+
+networks:
+  pipeline-net:
+    name: pipeline-net


### PR DESCRIPTION
## Summary
- add health checks for kafka, postgres, redis, producer, and consumer containers
- introduce pipeline-net custom network and attach all services

## Testing
- `pre-commit run --files docker-compose.yml` *(fails: command not found)*
- `docker compose config` *(fails: command not found)*
- `pytest -q` *(fails: fixture 'event' not found; async plugins missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a68787e238832e984e60d05e05bde5