### PR TITLE
Add Terraform infrastructure scaffolding

### DIFF
--- a/infra/terraform/budgets.tf
+++ b/infra/terraform/budgets.tf
@@ -1,1 +1,16 @@
-# TODO: AWS Budgets alarm using TODO_BUDGET_AMOUNT and TODO_SNS_TOPIC_ARN_FOR_BUDGETS.
+resource "aws_budgets_budget" "monthly" {
+  name         = "monthly-budget"
+  budget_type  = "COST"
+  limit_amount = tostring(var.TODO_BUDGET_AMOUNT)
+  limit_unit   = "USD"
+  time_unit    = "MONTHLY"
+
+  notification {
+    comparison_operator = "GREATER_THAN"
+    threshold           = 100
+    threshold_type      = "PERCENTAGE"
+    notification_type   = "FORECASTED"
+
+    subscriber_sns_topic_arns = [var.TODO_SNS_TOPIC_ARN_FOR_BUDGETS]
+  }
+}

--- a/infra/terraform/ecs.tf
+++ b/infra/terraform/ecs.tf
@@ -1,1 +1,35 @@
-# TODO: ECS cluster, task definitions, and services using TODO_ECS_CLUSTER_NAME and related variables.
+resource "aws_ecs_cluster" "main" {
+  name = var.TODO_ECS_CLUSTER_NAME
+}
+
+resource "aws_ecs_task_definition" "api" {
+  family                   = var.TODO_ECS_API_TASKDEF_NAME
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = "256"
+  memory                   = "512"
+  container_definitions    = jsonencode([])
+}
+
+resource "aws_ecs_task_definition" "worker" {
+  family                   = var.TODO_ECS_WORKER_TASKDEF_NAME
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = "256"
+  memory                   = "512"
+  container_definitions    = jsonencode([])
+}
+
+resource "aws_ecs_service" "this" {
+  count           = length(var.TODO_ECS_SERVICE_NAMES)
+  name            = var.TODO_ECS_SERVICE_NAMES[count.index]
+  cluster         = aws_ecs_cluster.main.id
+  task_definition = aws_ecs_task_definition.api.arn
+  desired_count   = 1
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    subnets         = aws_subnet.private[*].id
+    security_groups = [aws_security_group.default.id]
+  }
+}

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -1,0 +1,4 @@
+# Root module stitching together all infrastructure components.
+# Individual services are defined in their respective *.tf files
+# (networking.tf, msk.tf, ecs.tf, rds.tf, redis.tf, observability.tf, budgets.tf).
+# Terraform automatically combines these files into a single configuration.

--- a/infra/terraform/msk.tf
+++ b/infra/terraform/msk.tf
@@ -1,1 +1,26 @@
-# TODO: MSK Serverless cluster and topics using TODO_MSK_CLUSTER_ARN and TODO_KAFKA_TOPIC_ORDERS, TODO_KAFKA_TOPIC_FLAGGED.
+resource "aws_msk_serverless_cluster" "this" {
+  cluster_name = "async-pipeline"
+
+  vpc_config {
+    subnet_ids     = aws_subnet.private[*].id
+    security_groups = [aws_security_group.default.id]
+  }
+
+  client_authentication {
+    sasl {
+      iam = true
+    }
+  }
+}
+
+resource "aws_msk_topic" "orders" {
+  cluster_arn = aws_msk_serverless_cluster.this.arn
+  topic_name  = var.TODO_KAFKA_TOPIC_ORDERS
+  partitions  = 1
+}
+
+resource "aws_msk_topic" "flagged" {
+  cluster_arn = aws_msk_serverless_cluster.this.arn
+  topic_name  = var.TODO_KAFKA_TOPIC_FLAGGED
+  partitions  = 1
+}

--- a/infra/terraform/networking.tf
+++ b/infra/terraform/networking.tf
@@ -1,1 +1,37 @@
-# TODO: VPC, subnets, route tables, and security groups using TODO_VPC_CIDR and related variables.
+resource "aws_vpc" "main" {
+  cidr_block = var.TODO_VPC_CIDR
+}
+
+resource "aws_subnet" "public" {
+  count                   = length(var.TODO_PUBLIC_SUBNET_IDS)
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = var.TODO_PUBLIC_SUBNET_IDS[count.index]
+  map_public_ip_on_launch = true
+}
+
+resource "aws_subnet" "private" {
+  count      = length(var.TODO_PRIVATE_SUBNET_IDS)
+  vpc_id     = aws_vpc.main.id
+  cidr_block = var.TODO_PRIVATE_SUBNET_IDS[count.index]
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+}
+
+resource "aws_route_table_association" "public" {
+  count          = length(aws_subnet.public)
+  subnet_id      = aws_subnet.public[count.index].id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_security_group" "default" {
+  vpc_id = aws_vpc.main.id
+  name   = "default"
+}
+
+resource "aws_security_group" "extra" {
+  count = length(var.TODO_SECURITY_GROUP_IDS)
+  vpc_id = aws_vpc.main.id
+  name   = var.TODO_SECURITY_GROUP_IDS[count.index]
+}

--- a/infra/terraform/observability.tf
+++ b/infra/terraform/observability.tf
@@ -1,1 +1,15 @@
-# TODO: CloudWatch log groups and Grafana workspace using TODO_CLOUDWATCH_LOG_GROUP_API, TODO_CLOUDWATCH_LOG_GROUP_WORKER, and TODO_GRAFANA_WORKSPACE.
+resource "aws_cloudwatch_log_group" "api" {
+  name              = var.TODO_CLOUDWATCH_LOG_GROUP_API
+  retention_in_days = 14
+}
+
+resource "aws_cloudwatch_log_group" "worker" {
+  name              = var.TODO_CLOUDWATCH_LOG_GROUP_WORKER
+  retention_in_days = 14
+}
+
+resource "aws_grafana_workspace" "main" {
+  name                  = var.TODO_GRAFANA_WORKSPACE
+  account_access_type   = "CURRENT_ACCOUNT"
+  authentication_providers = ["AWS_SSO"]
+}

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -1,1 +1,47 @@
-# TODO: output ARNs and hostnames for CI consumption.
+output "vpc_id" {
+  value = aws_vpc.main.id
+}
+
+output "public_subnet_ids" {
+  value = aws_subnet.public[*].id
+}
+
+output "private_subnet_ids" {
+  value = aws_subnet.private[*].id
+}
+
+output "security_group_ids" {
+  value = concat([aws_security_group.default.id], aws_security_group.extra[*].id)
+}
+
+output "msk_cluster_arn" {
+  value = aws_msk_serverless_cluster.this.arn
+}
+
+output "msk_bootstrap_brokers" {
+  value = aws_msk_serverless_cluster.this.bootstrap_brokers_sasl_iam
+}
+
+output "ecs_cluster_arn" {
+  value = aws_ecs_cluster.main.arn
+}
+
+output "ecs_service_arns" {
+  value = aws_ecs_service.this[*].id
+}
+
+output "rds_instance_arn" {
+  value = aws_db_instance.main.arn
+}
+
+output "rds_endpoint" {
+  value = aws_db_instance.main.endpoint
+}
+
+output "redis_endpoint" {
+  value = aws_elasticache_replication_group.main.primary_endpoint_address
+}
+
+output "grafana_workspace_arn" {
+  value = aws_grafana_workspace.main.arn
+}

--- a/infra/terraform/rds.tf
+++ b/infra/terraform/rds.tf
@@ -1,1 +1,29 @@
-# TODO: RDS Postgres instance referencing TODO_RDS_DB_NAME and TODO_RDS_SECRET_ID.
+data "aws_secretsmanager_secret" "db" {
+  arn = var.TODO_RDS_SECRET_ID
+}
+
+data "aws_secretsmanager_secret_version" "db" {
+  secret_id = data.aws_secretsmanager_secret.db.id
+}
+
+locals {
+  db_creds = jsondecode(data.aws_secretsmanager_secret_version.db.secret_string)
+}
+
+resource "aws_db_subnet_group" "main" {
+  name       = "${var.TODO_RDS_DB_NAME}-subnet-group"
+  subnet_ids = aws_subnet.private[*].id
+}
+
+resource "aws_db_instance" "main" {
+  identifier              = var.TODO_RDS_DB_NAME
+  engine                  = "postgres"
+  instance_class          = "db.t3.micro"
+  allocated_storage       = 20
+  db_name                 = var.TODO_RDS_DB_NAME
+  username                = local.db_creds.username
+  password                = local.db_creds.password
+  skip_final_snapshot     = true
+  vpc_security_group_ids  = [aws_security_group.default.id]
+  db_subnet_group_name    = aws_db_subnet_group.main.name
+}

--- a/infra/terraform/redis.tf
+++ b/infra/terraform/redis.tf
@@ -1,1 +1,14 @@
-# TODO: ElastiCache Redis cluster using TODO_ELASTICACHE_CLUSTER_ID and TODO_REDIS_ENDPOINT.
+resource "aws_elasticache_subnet_group" "main" {
+  name       = "${var.TODO_ELASTICACHE_CLUSTER_ID}-subnet-group"
+  subnet_ids = aws_subnet.private[*].id
+}
+
+resource "aws_elasticache_replication_group" "main" {
+  replication_group_id       = var.TODO_ELASTICACHE_CLUSTER_ID
+  engine                     = "redis"
+  node_type                  = "cache.t3.micro"
+  number_cache_clusters      = 1
+  subnet_group_name          = aws_elasticache_subnet_group.main.name
+  security_group_ids         = [aws_security_group.default.id]
+  automatic_failover_enabled = false
+}


### PR DESCRIPTION
## Summary
- define VPC, subnets, and security groups
- provision MSK, ECS, RDS, Redis, observability, and budget resources
- expose infrastructure identifiers via Terraform outputs

## Testing
- `terraform fmt -recursive` *(fails: command not found)*
- `terraform validate` *(not run: terraform unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68a687897efc832e8378312b147107a4