### PR TITLE
Add integration and load tests with Testcontainers

### DIFF
--- a/tests/integration/test_producer.py
+++ b/tests/integration/test_producer.py
@@ -1,5 +1,52 @@
-import pytest
+import asyncio
+import os
+import uuid
 
-@pytest.mark.skip("Integration test placeholder")
-def test_producer_kafka() -> None:
-    pass
+import asyncpg
+import pytest
+from aiokafka import AIOKafkaConsumer
+from httpx import AsyncClient
+from testcontainers.kafka import KafkaContainer
+from testcontainers.postgres import PostgresContainer
+
+from app.producer.main import app
+
+
+@pytest.mark.asyncio
+async def test_producer_kafka() -> None:
+    """Producer publishes to Kafka with backing Postgres using Testcontainers."""
+    with PostgresContainer("postgres:16") as pg, KafkaContainer() as kafka:
+        os.environ["DATABASE_URL"] = pg.get_connection_url()
+        os.environ["KAFKA_BOOTSTRAP_SERVERS"] = kafka.get_bootstrap_server()
+
+        # Verify Postgres is reachable
+        conn = await asyncpg.connect(pg.get_connection_url())
+        await conn.execute("SELECT 1;")
+        await conn.close()
+
+        # Produce event via FastAPI endpoint
+        event = {
+            "event_id": str(uuid.uuid4()),
+            "order_id": str(uuid.uuid4()),
+            "timestamp": 1,
+            "source": "test",
+            "event_type": "ORDER_CREATED",
+            "payload": "{}",
+        }
+        async with AsyncClient(app=app, base_url="http://test") as client:
+            resp = await client.post("/events", json=event)
+            assert resp.status_code == 200
+
+        # Consume produced message from Kafka
+        consumer = AIOKafkaConsumer(
+            os.getenv("KAFKA_TOPIC_ORDERS", "orders.raw"),
+            bootstrap_servers=os.environ["KAFKA_BOOTSTRAP_SERVERS"],
+            group_id="test-group",
+            auto_offset_reset="earliest",
+        )
+        await consumer.start()
+        try:
+            msg = await asyncio.wait_for(consumer.getone(), timeout=10)
+            assert msg is not None
+        finally:
+            await consumer.stop()

--- a/tests/load/test_placeholder.py
+++ b/tests/load/test_placeholder.py
@@ -1,5 +1,0 @@
-import pytest
-
-@pytest.mark.skip("Load test placeholder")
-def test_load() -> None:
-    pass

--- a/tests/load/test_simulator.py
+++ b/tests/load/test_simulator.py
@@ -1,0 +1,42 @@
+import asyncio
+import os
+import sys
+import uuid
+from pathlib import Path
+
+import pytest
+from aiokafka import AIOKafkaConsumer
+from testcontainers.kafka import KafkaContainer
+
+sys.path.append(str(Path(__file__).resolve().parents[2] / "tools"))
+import simulator
+
+
+@pytest.fixture(scope="module")
+def kafka_bootstrap() -> str:
+    with KafkaContainer() as kafka:
+        server = kafka.get_bootstrap_server()
+        os.environ["KAFKA_BOOTSTRAP_SERVERS"] = server
+        yield server
+
+
+async def consume_one(bootstrap: str, group_id: str) -> None:
+    consumer = AIOKafkaConsumer(
+        os.getenv("KAFKA_TOPIC_ORDERS", "orders.raw"),
+        bootstrap_servers=bootstrap,
+        group_id=group_id,
+        auto_offset_reset="earliest",
+    )
+    await consumer.start()
+    try:
+        msg = await asyncio.wait_for(consumer.getone(), timeout=10)
+        assert msg is not None
+    finally:
+        await consumer.stop()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("rps", [1, 5])
+async def test_load_simulator(kafka_bootstrap: str, rps: int) -> None:
+    await simulator.produce(rps, 1)
+    await consume_one(kafka_bootstrap, f"load-{rps}-{uuid.uuid4()}")


### PR DESCRIPTION
## Summary
- Spin up Kafka and Postgres via Testcontainers for producer integration test
- Add load-testing scenarios invoking simulator using Kafka test container

## Testing
- `pytest -q` *(fails: docker.errors.DockerException: Error while fetching server API version)*

------
https://chatgpt.com/codex/tasks/task_e_68a6878a86fc832e85fef523cf03dceb