### PR TITLE
Add dbt models and nightly dbt workflow

### DIFF
--- a/ci/github/workflows/nightly-dbt.yml
+++ b/ci/github/workflows/nightly-dbt.yml
@@ -6,6 +6,13 @@ on:
 jobs:
   dbt:
     runs-on: ubuntu-latest
+    env:
+      DBT_PROFILES_DIR: dbt
     steps:
       - uses: actions/checkout@v4
-      - run: echo "TODO: run dbt models and docs"
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - run: pip install dbt-postgres
+      - run: dbt run --project-dir dbt
+      - run: dbt docs generate --project-dir dbt

--- a/dbt/models/conversion_funnel.sql
+++ b/dbt/models/conversion_funnel.sql
@@ -1,0 +1,13 @@
+with page_views as (
+    select distinct user_id from {{ source('analytics', 'page_views') }}
+),
+signups as (
+    select distinct user_id from {{ source('analytics', 'signups') }}
+),
+purchases as (
+    select distinct user_id from {{ source('sales', 'orders') }}
+)
+select
+    (select count(*) from page_views) as total_page_views,
+    (select count(*) from signups) as total_signups,
+    (select count(*) from purchases) as total_purchases

--- a/dbt/models/daily_sales.sql
+++ b/dbt/models/daily_sales.sql
@@ -1,0 +1,6 @@
+select
+    order_date::date as order_date,
+    sum(amount) as total_sales
+from {{ source('sales', 'orders') }}
+group by 1
+order by 1

--- a/dbt/profiles.yml
+++ b/dbt/profiles.yml
@@ -1,0 +1,13 @@
+default:
+  target: dev
+  outputs:
+    dev:
+      type: postgres
+      host: "{{ env_var('DBT_HOST') }}"
+      user: "{{ env_var('DBT_USER') }}"
+      password: "{{ env_var('DBT_PASSWORD') }}"
+      port: "{{ env_var('DBT_PORT') | int }}"
+      dbname: "{{ env_var('DBT_DBNAME') }}"
+      schema: "{{ env_var('DBT_SCHEMA') }}"
+      threads: 1
+      keepalives_idle: 0


### PR DESCRIPTION
## Summary
- add dbt models for daily sales and conversion funnel
- configure env-driven dbt profile
- run dbt jobs nightly with dbt run and docs generate

## Testing
- `pre-commit run --files dbt/models/daily_sales.sql dbt/models/conversion_funnel.sql dbt/profiles.yml ci/github/workflows/nightly-dbt.yml` *(fails: command not found)*
- `pip install pre-commit` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a6878b8180832e9c8d33746d62dc07