### PR TITLE
Add httpx dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,8 @@ dependencies = [
     "black",
     "isort",
     "ruff",
-    "mypy"
+    "mypy",
+    "httpx"
 ]
 
 [tool.black]


### PR DESCRIPTION
## Summary
- add `httpx` to project dependencies

## Testing
- `pre-commit run --all-files` *(fails: command not found)*
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `pip install httpx` *(fails: Could not find a version that satisfies the requirement httpx)*

------
https://chatgpt.com/codex/tasks/task_e_68a76e97fae8832e9e00c4943186b496