### PR TITLE
feat: use redis stack image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,7 +58,7 @@ services:
       - pipeline-net
 
   redis:
-    image: redis:7
+    image: redis/redis-stack:7
     ports:
       - '6379:6379'
     healthcheck:


### PR DESCRIPTION
## Summary
- use Redis Stack image to provide RedisBloom support

## Testing
- `pre-commit run --files docker-compose.yml` *(fails: command not found)*
- `pip install pre-commit` *(fails: Could not find a version due to proxy 403)*
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a776b4a088832ebbd835f66efcfee3