### PR TITLE
Initialize Alembic and add OrderEvent migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,17 @@ Python 3.12, FastAPI, aiokafka, Redis, Postgres, Terraform, GitHub Actions, dbt.
 ## Local Workflow
 `make dev-bootstrap` then `make compose-up` to start local stack; `make test` for tests.
 
+## Database Migrations
+Alembic migrations live under `app/db/alembic/`. Ensure `DATABASE_URL` is set in your environment, then run:
+
+```bash
+# create a new migration after model changes
+alembic -c app/db/alembic/alembic.ini revision --autogenerate -m "message"
+
+# apply migrations
+alembic -c app/db/alembic/alembic.ini upgrade head
+```
+
 ## Runtime Environment Variables
 Set these in a `.env` file or your shell:
 

--- a/app/db/alembic/alembic.ini
+++ b/app/db/alembic/alembic.ini
@@ -1,0 +1,37 @@
+[alembic]
+script_location = app/db/alembic
+sqlalchemy.url = ${DATABASE_URL}
+
+default_timezone = utc
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s

--- a/app/db/alembic/env.py
+++ b/app/db/alembic/env.py
@@ -1,0 +1,70 @@
+import asyncio
+import os
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy import pool
+from sqlalchemy.ext.asyncio import async_engine_from_config
+from sqlmodel import SQLModel
+
+from app.db import models  # noqa: F401 ensures models are imported
+
+# this is the Alembic Config object, which provides
+# access to the values within the .ini file in use.
+config = context.config
+
+# Interpret the config file for Python logging.
+# This line sets up loggers basically.
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+# override sqlalchemy.url with DATABASE_URL env var if set
+config.set_main_option(
+    "sqlalchemy.url", os.getenv("DATABASE_URL", "sqlite+aiosqlite:///./events.db")
+)
+
+target_metadata = SQLModel.metadata
+
+
+def run_migrations_offline() -> None:
+    """Run migrations in 'offline' mode."""
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def do_run_migrations(connection) -> None:
+    context.configure(connection=connection, target_metadata=target_metadata)
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    """Run migrations in 'online' mode."""
+
+    connectable = async_engine_from_config(
+        config.get_section(config.config_ini_section),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    async def async_run_migrations() -> None:
+        async with connectable.connect() as connection:
+            await connection.run_sync(do_run_migrations)
+        await connectable.dispose()
+
+    asyncio.run(async_run_migrations())
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/app/db/alembic/versions/0001_create_order_event_table.py
+++ b/app/db/alembic/versions/0001_create_order_event_table.py
@@ -1,0 +1,31 @@
+"""create OrderEvent table
+
+Revision ID: 0001
+Revises:
+Create Date: 2024-06-01 00:00:00.000000
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0001"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "orderevent",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("event_id", sa.String(), nullable=False),
+        sa.Column("order_id", sa.String(), nullable=False),
+        sa.Column("payload", sa.String(), nullable=False),
+    )
+    op.create_index("ix_orderevent_event_id", "orderevent", ["event_id"], unique=True)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_orderevent_event_id", table_name="orderevent")
+    op.drop_table("orderevent")


### PR DESCRIPTION
## Summary
- set up Alembic configuration and async env
- add initial migration for the OrderEvent table
- document how to create and run migrations

## Testing
- `pre-commit run --files README.md app/db/alembic/alembic.ini app/db/alembic/env.py app/db/alembic/versions/0001_create_order_event_table.py` *(failed: command not found)*
- `pip install pre-commit` *(failed: Could not find a version that satisfies the requirement pre-commit)*
- `pytest` *(failed: ModuleNotFoundError: No module named 'app')*
- `black app/db/alembic/env.py app/db/alembic/versions/0001_create_order_event_table.py`
- `isort app/db/alembic/env.py app/db/alembic/versions/0001_create_order_event_table.py`
- `ruff check app/db/alembic/env.py app/db/alembic/versions/0001_create_order_event_table.py`
- `mypy --explicit-package-bases app/db/alembic/env.py app/db/alembic/versions/0001_create_order_event_table.py` *(failed: session.py overload error)*

------
https://chatgpt.com/codex/tasks/task_e_68a7822ab0c8832ea688b8b87b03f9c0